### PR TITLE
Add Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "leaflet-color-markers",
+  "homepage": "https://github.com/pointhi/leaflet-color-markers",
+  "authors": [
+    "Thomas Pointhuber <thomas.pointhuber@gmx.at>"
+  ],
+  "description": "color variations of the standard leaflet marker",
+  "main": "js/leaflet-color-markers.js",
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "leaflet": ">=0.7.0"
+  }
+}


### PR DESCRIPTION
This PR adds a bower.json file as suggested in issue #9.

Once this is merged, the project needs to be registered with Bower as described here:

https://bower.io/docs/creating-packages/#register

(Just a matter of installing Bower and running `bower register leaflet-color-markers https://github.com/pointhi/leaflet-color-markers`).

Bower also expects tagged versions using semantic versioning, so it would be great to tag the current master branch with v1.0.0 to get things started.

Please let me know if you have questions or concerns or if I can do anything else to help out. (Admittedly, I'm new to Bower as well, so apologies if I've made any newbie mistakes... but it seems pretty straightforward).

Thanks again!
