### PR TITLE
Change icon file server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ color variations of the standard leaflet markers:
 ### Usage
 ```javascript
 var greenIcon = new L.Icon({
-  iconUrl: 'https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
   iconSize: [25, 41],
   iconAnchor: [12, 41],


### PR DESCRIPTION
It looks like [rawgit.com is sunsetting](https://rawgit.com/) and the readme itself loads the icon from githubusercontent.com.